### PR TITLE
Fixed main attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "timesolver",
   "version": "1.2.0",
   "description": "A small library for manipulating, validating and formatting JavaScript date object.",
-  "main": "src/1.1.1/timeSolver.min.js",
+  "main": "timeSolver.min.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
The main attribute was set to ```main":  src/1.1.1/timeSolver.min.js``` which did not work after installing with ```npm i ``` changed to ``` main": "timeSolver.min.js"```